### PR TITLE
Updating contributor doc + templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,16 +4,8 @@ Enter a title and short description of the proposed changes. Tag @ACharbonneau o
 
 Please place an 'x' between the brackets to indicate a yes answer to the questions below.
 
-For previewing your changes:
-- [ ] A descriptive title
-- [ ] Please provide a short description of the changes you're requesting.
-- [ ] Is this pull request mergeable?
-- [ ] Did the pull request build checks complete successfully?
-- [ ] Did the repo's bot auto-merge your changes to the preview branch?
-- [ ] Check your changes on the preview website. It may take ~30 minutes for the changes to show up.
-
 For requesting final pull request to the master branch:
 - [ ] A descriptive title
 - [ ] Please provide a short description of the changes you're requesting.
-- [ ] Did the changes render as expected on the preview website?
+- [ ] Is this pull request mergeable?
 - [ ] Request review from @ACharbonneau and @marisalim

--- a/library_file_templates/library-obj-template.md
+++ b/library_file_templates/library-obj-template.md
@@ -1,0 +1,3 @@
+---
+title: Add objective title without file ID
+---

--- a/library_file_templates/library-obj-template.md
+++ b/library_file_templates/library-obj-template.md
@@ -1,3 +1,5 @@
 ---
 title: Add objective title without file ID
 ---
+
+Add a brief ~1-2 sentence description of the objective

--- a/library_file_templates/library-persona-template.md
+++ b/library_file_templates/library-persona-template.md
@@ -1,0 +1,11 @@
+---
+title: Add persona title without file ID
+---
+
+Add a short description of the persona's biological/computational experience level, their role and responsibilities, and relation to any of the other personas in the Use Case Library
+
+### Assumptions
+
+Users with this persona:
+
+-   Add assumptions as bullet points

--- a/library_file_templates/library-reqs-template.md
+++ b/library_file_templates/library-reqs-template.md
@@ -1,0 +1,3 @@
+---
+title: Add requirements title without file ID
+---

--- a/library_file_templates/library-reqs-template.md
+++ b/library_file_templates/library-reqs-template.md
@@ -1,3 +1,6 @@
 ---
 title: Add requirements title without file ID
+completed: This date will be added by Use Case committee
 ---
+
+Add a brief ~1-2 sentence description of the requirement

--- a/library_file_templates/library-task-template.md
+++ b/library_file_templates/library-task-template.md
@@ -1,5 +1,8 @@
 ---
 title: Add user task title without file ID
+completed: This date will be added by Use Case committee
 requirements:
-- Add requirements file ID
+- Add requirements file ID (e.g., r-00018)
 ---
+
+Add a brief ~1-2 sentence description of the user task

--- a/library_file_templates/library-task-template.md
+++ b/library_file_templates/library-task-template.md
@@ -1,0 +1,5 @@
+---
+title: Add user task title without file ID
+requirements:
+- Add requirements file ID
+---

--- a/library_file_templates/library-uc-template.md
+++ b/library_file_templates/library-uc-template.md
@@ -2,7 +2,7 @@
 title: Add use case title without file ID
 completed: This date will be added by Use Case committee
 tutorial: If applicable, tutorial link will be added by Use Case committee
-goals: Goals will be added by Use Case committee
+goal: You can add goals or Use Case committee can add them
 persona:
 - Add persona file ID (e.g., p-001)
 objective:

--- a/library_file_templates/library-uc-template.md
+++ b/library_file_templates/library-uc-template.md
@@ -1,0 +1,13 @@
+---
+title: Add use case title without file ID
+persona:
+- Add persona file ID
+objective:
+- Add objective file ID
+user_tasks:
+- Add user task file ID
+requirements:
+- Add requirements file ID
+---
+
+Add use case summary description here, framed as a scenario with a hypothetical user.

--- a/library_file_templates/library-uc-template.md
+++ b/library_file_templates/library-uc-template.md
@@ -1,13 +1,16 @@
 ---
 title: Add use case title without file ID
+completed: This date will be added by Use Case committee
+tutorial: If applicable, tutorial link will be added by Use Case committee
+goals: Goals will be added by Use Case committee
 persona:
-- Add persona file ID
+- Add persona file ID (e.g., p-001)
 objective:
-- Add objective file ID
+- Add objective file ID (e.g., obj-0001)
 user_tasks:
-- Add user task file ID
+- Add user task file ID (e.g., t-0001)
 requirements:
-- Add requirements file ID
+- Add requirements file ID (e.g., r-00001)
 ---
 
 Add use case summary description here, framed as a scenario with a hypothetical user.

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -18,46 +18,40 @@ If you are OK with these two conditions, then we welcome both you and your contr
 
 ## How to add content
 
-If you have a suggestion for a new use case concept and are not familiar with GitHub, you can [email your idea to us](mailto:autohelp+int+851+6545985337373134556@CFDE.groups.io).
+If you have a suggestion for a new use case concept and are not familiar with GitHub, you can [email your idea to us](mailto:support@cfde.atlassian.net).
 
 If you are familiar with GitHub please either:
 
-  - Open a [`NewUseCase issue`](https://github.com/nih-cfde/usecases/issues/new?labels=new+use+case&template=NewUseCase_template.md&title=Add+use+case+idea+title) describing your new use case idea
+  - Open a [`NewUseCase issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=new+use+case&template=NewUseCase_template.md&title=Add+use+case+idea+title) describing your new use case idea
 
   - Or write up your use case and submit it as a pull request (PR). Please follow the [Use Case Style Guide](#usecasestyle) below.
 
 ### PR process
 If you are submitting a pull request, please create one pull request per use case so admin can check the complete change.
 
-**First, add and preview new changes:**
+  - [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the [use case library repo](https://github.com/nih-cfde/use-case-library-build) and create a new branch in your forked version.
 
-  - [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the [use cases repo](https://github.com/nih-cfde/usecases) and create a new branch in your forked version.
-  - Use the [use case file templates](https://github.com/nih-cfde/usecases/tree/master/docs/template_files) to format and add your new use case files to the appropriate directories on your branch.
-  - After you add changes to your branch, you should see a message near the top of the repo page indicating that your branch is x number of commits ahead of `nih-cfde:master`. There should be a button for 'Pull request' and/or 'Compare' - they lead to the same page to create a PR. Submit a PR from your forked repo branch to the `nih-cfde:preview` branch.
-  - After you submit the PR, make sure the repo checks complete (green check mark)
-  - If the checks complete successfully, the repo's bot will auto-merge your changes to the `preview` branch. Please check your changes on the [preview website](https://cfde-usecases.readthedocs-hosted.com/en/preview/). It may take ~30 minutes for the changes you added to show up.
-      - Please check that the new content renders correctly (e.g., check page format, right-side table of contents links, and page and web hyperlinks) and makes sense relative to existing content.
-      - If the checks failed, please submit a [`HelpWanted issue`](https://github.com/nih-cfde/usecases/issues/new?labels=help+wanted&template=help_template.md&title=Add+problem+title) to request help. Please include a reference (using `#`) to your PR so we can check the correct website build logs.
+  **New use case files should ONLY be added to the [`library` directory](https://github.com/nih-cfde/use-case-library-build/tree/latest/library). Please do not change any other files in the repository!**
 
-**Second, when you are satisfied with the changes:**
-
-  - Create a new PR from your branch to the `nih-cfde:master` branch.
+  - Use the [use case file templates](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates) to format and add your new use case files to the `library` directory on your branch.
+  - After you add changes to your branch, you should see a message near the top of the repo page indicating that your branch is x number of commits ahead of `nih-cfde:latest`. There should be a button for "Pull request" and/or "Compare" - they lead to the same page to create a PR. Submit a PR pushing changes from your branch to `nih-cfde:latest`.
   - Request reviews from Use Case maintainers by typing `@ACharbonneau` and `@marisalim` in your PR text box
-  - After you submit the PR, make sure the repo checks complete (green check mark)
   - Please allow up to one week for admin to review your request
+
+If you need help at any point in this process, please submit a [`HelpWanted issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=help+wanted&template=help_template.md&title=Add+problem+title)! Please include a reference (using `#`) to your PR number so we can check the submission.
 
 ### Use Case approval process
 
 The Use Case committee will mark proposed use cases, and corresponding requirements pages, as `in progress`=&#x23F3;, `approved`=&#x1F44C;, and `done`=&#x2705;, as appropriate.
 
-If you have any questions about contributing, please submit an issue and we will lend a hand ASAP:
+If you have any questions about contributing, please submit an issue and we will lend a hand as soon as possible:
 
 Issue templates | About
 --- | ---
-[`NewUseCase issue`](https://github.com/nih-cfde/usecases/issues/new?labels=new+use+case&template=NewUseCase_template.md&title=Add+use+case+idea+title) | To describe and suggest a new use case idea
-[`Enhancements issue`](https://github.com/nih-cfde/usecases/issues/new?labels=enhancement&template=Enhancement_template.md&title=Add+suggested+enhancement+title) | To suggest general improvements to the Use Case Repository
-[`HelpWanted issue`](https://github.com/nih-cfde/usecases/issues/new?labels=help+wanted&template=help_template.md&title=Add+problem+title) | To request general help
-[`Bug report issue`](https://github.com/nih-cfde/usecases/issues/new?labels=bug&template=bug_template.md&title=Add+bug+title) | To report a bug
+[`NewUseCase issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=new+use+case&template=NewUseCase_template.md&title=Add+use+case+idea+title) | To describe and suggest a new use case idea
+[`Enhancements issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=enhancement&template=Enhancement_template.md&title=Add+suggested+enhancement+title) | To suggest general improvements to the Use Case Library
+[`HelpWanted issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=help+wanted&template=help_template.md&title=Add+problem+title) | To request general help
+[`Bug report issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=bug&template=bug_template.md&title=Add+bug+title) | To report a bug
 
 Thank you for being here and for being a part of the CFDE project!
 
@@ -73,91 +67,70 @@ Thank you for being here and for being a part of the CFDE project!
 - See [glossary](./glossary.md) for definitions
 - Each persona, objective, user task, and requirement needs its own description page that will be linked to the corresponding use case page(s). Common user tasks and requirements should be reused across use cases.
 
-### General File Format
+### General File Format Guidelines
+
+**File names** should be lower case, use hyphens between words, and match the page titles (but try to keep them concise). All files should include a unique file ID. As indicated below, please add the appropriate number of leading 0's to the file IDs. The Use Case committee will finalize file IDs to ensure they do not clash with existing IDs.
+
+   File type | File prefix | Example
+   --- | --- | ---
+   use case | uc-0000 | uc-0001-researcher-browse-and-filter.md
+   persona | p-000 | p-001-clinical-researcher.md
+   objective | obj-0000 | obj-0001-create-data-release.md
+   user task | t-0000 | t-0001-access-cfde-interface.md
+   requirement | r-00000 | r-00001-the-interface-will-support-gui-web-access-to-end-users.md
 
 The **file format** for all files should be written in Markdown.
 
 - For help with Markdown syntax, see this [basic syntax guide](https://www.markdownguide.org/basic-syntax/)
 - To add links to other pages:
-
 ```
 # syntax
 [<text to click on>](<Github repo relative path to file>)
 
-# This is an example for a link to the Personas description page for 'Clinical Researcher':
-[Clinical Researcher](../personas/clinical-researcher.md)
+# This is an example for a link to the Personas description page for "Clinical Researcher":
+[Clinical Researcher](./p-001-clinical-researcher.md)
 ```
 
-The **site index** is automatically created by yaml headers in each file (only the title will be visible on the rendered website). See [template files](https://github.com/nih-cfde/usecases/tree/master/docs/template_files) for example structure.
+The **site index** is automatically created by yaml headers at the top of each file. These headers will automatically render links to the corresponding persona, objective, user task, and requirements files associated with a given use case. The Use Case committee will check yaml headers to ensure the indices do not clash with existing files.
 
-  The `parent` yaml value depends on the website tab the Use Case file appears in:
+Yaml format begins and ends with "---". Every use case library page should have a `title:` key. For the [use case](#use-case-files) (uc-0000) and [user task](#user-task-files) (t-0000) files, additional keys and values are currently required. The additional keys (e.g., `requirements:`) are followed by a colon ":" and their corresponding values are listed after with a hyphen "-" and the file ID. Yaml keys may have one or more values. For example, the `requirements:` key below is linked to the `r-00003` and `r-00004` requirements file IDs:
 
-  `parent:` value | About
-  --- | ---
-  `Use Cases` | for the main Use Case file
-  `Personas` | for persona files
-  `Objectives` | for objective files
-  `User Tasks` | for user task files
-  `Requirements` | for requirements files
+```
+---
+title: example user task
+requirements:
+- r-00003
+- r-00004
+---
+```
 
-  The Use Case committee will finalize yaml header page numbers to ensure they do not clash with existing files.
-
-**File names** should be lower case, have hyphens, and match the heading (but try to keep them concise). Use Case (`ucXXXX`), User Task (`tXXXX`), and Requirement (`rXXXXX`) files should include a file ID numbered in order of appearance in this Use Case Repository website.
-
-   File type | Example
-   --- | ---
-   use case | uc0001-researcher-browse-and-filter.md
-   persona | clinical-researcher.md
-   objective | create-data-release.md
-   user task | t0001-access-cfde-interface.md
-   requirement | r00001-the-interface-will-support-gui-web-access-to-end-users.md
-
-   The Use Case committee will finalize Use Case, User Task, and Requirement file IDs to ensure they do not clash with existing IDs.
-
-### `Use Case` files
-- Use Case titles always begin with their `UCXXXX` ID
-- Use the [use case file template](https://github.com/nih-cfde/usecases/tree/master/docs/template_files/use-case-template.md) to enter the required sections
+### `Use Case` files <a name="use-case-files"></a>
+- Use the [use case file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-uc-template.md) to enter the required sections
 - Required sections:
-    - yaml index header
-    - Page header: title, date completed (`<month> <year>`), persona, objective
-    - `Summary`: a short summary of the use case
-    - `User Tasks`: a bullet point list of the tasks required for the use case, including links to each task page. Tasks are numbered by `TXXXX`.
-    - `Requirements`: a bullet point list of the requirements for each task, including links to each requirement page. Requirements are numbered by `RXXXXX`.
-- The persona, objective, user tasks, and requirements need to be linked to their corresponding description page (detailed in the following sections)
-- Save use case files in the [use-cases directory](https://github.com/nih-cfde/usecases/tree/master/docs/use-cases)
+    - yaml index header, including keys for `title:`, `persona:`, `objective:`, `user_tasks:`, and `requirements:`
+    - a short summary of the use case
 
 ### `Persona` files
-- Use the [persona file template](https://github.com/nih-cfde/usecases/tree/master/docs/template_files/persona-template.md) to enter the required sections
+- Use the [persona file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-persona-template.md) to enter the required sections
 - Required sections:
-    - yaml index header
-    - Short description of their biological/computational experience, their role and responsibilities, and relation to any of the other Personas in the Use Cases Repository
-    - A section listing assumptions about the persona's credentials e.g., access to the CFDE
-- Save persona files in the [personas directory](https://github.com/nih-cfde/usecases/tree/master/docs/personas/)
+    - yaml index header with `title:`
+    - Short description of the persona's biological/computational experience, their role and responsibilities, and relation to any of the other personas in the Use Case Library
+    - A bullet point section listing assumptions about the persona's credentials e.g., access to the CFDE
 
 ### `Objective` files
-- Use the [objective file template](https://github.com/nih-cfde/usecases/tree/master/docs/template_files/objective-template.md) to enter the required sections
+- Use the [objective file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-obj-template.md) to enter the required sections
 - Required sections:
-    - yaml index header
-    - `<name of the task>`: brief ~1 sentence description of the task
-- Save objective files in the [objectives directory](https://github.com/nih-cfde/usecases/tree/master/docs/objectives/)
+    - yaml index header with `title:`
+    - **STILL NEEDED????** `<name of the task>`: brief ~1 sentence description of the task
 
-### `User task` files
+### `User task` files <a name="user-task-files"></a>
 - The User Tasks title should be short and self-explanatory, but please add a short description as needed for clarity
-- User Task titles always begin with their `TXXXX` ID
-- Use the [user task file template](https://github.com/nih-cfde/usecases/tree/master/docs/template_files/user-task-template.md) to enter the required sections
+- Use the [user task file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-task-template.md) to enter the required sections
 - Required sections:
-    - yaml index header
-    - `Appears in Use Cases`: bullet point list of the use case(s) that the task appears in, with page link to the use case page(s)
-- Save user task files in the [user-tasks directory](https://github.com/nih-cfde/usecases/tree/master/docs/user-tasks/)
+    - yaml index header with `title:` and `requirements:`
 
 ### `Requirement` files
 - The Requirements title should be short and self-explanatory, but please add a short description as needed for clarity
-- Requirement titles always begin with their `RXXXXX` ID
-- Use the [requirement file template](https://github.com/nih-cfde/usecases/tree/master/docs/template_files/requirement-template.md) to enter the required sections
+- Use the [requirement file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-reqs-template.md) to enter the required sections
 - Required sections:
-    - yaml index header
-    - Requirement title (same as yaml index title)
-    - An `Appears in` section with two sub-sections:
-      - Under `User Tasks`: bullet point list of the task(s) that the requirement appears in, with page link to the user task page
-      - Under `Use Cases`: bullet point list of the use case(s) that the requirement appears in, with page link to the use case page(s)
-- Save requirements files in the [requirements directory](https://github.com/nih-cfde/usecases/tree/master/docs/requirements/)
+    - yaml index header with `title:`

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -138,14 +138,22 @@ Thank you for being here and for being a part of the CFDE project!
 ## Use Case Repository Style Guide <a name="usecasestyle"></a>
 
 ### Use Case Structure
-- All Use Cases must have:
-    - a **Persona**
-    - an **Objective**
-    - a **Summary** of the Objective
-    - specific **User Tasks**
-    - technical infrastructure **Requirements** for each User Task
-- See [glossary](./glossary.md) for definitions
-- Each persona, objective, user task, and requirement needs its own description page that will be linked to the corresponding use case page(s). Common user tasks and requirements should be reused across use cases.
+
+- All use cases must have:
+    - a [**persona**](./glossary.md#persona)
+    - an [**objective**](./glossary.md#objective)
+    - a [**summary**](./glossary.md#summary) of the objective
+    - technical infrastructure [**requirements**](./glossary.md#requirement)
+    - specific [**user tasks**](./glossary.md#user-task)
+
+- Each use case submission consists of five types of file:
+    - 1 [use case file](#use-case-files)
+    - 1 [persona files](#persona-files)
+    - 1 [objective file](#obj-files)
+    - 1 or more [requirement files](#req-files)
+    - 1 or more [user task files](#user-task-files)
+
+Each persona, objective, requirement, and user task needs its own page and will be linked to the associated use case page(s). Common user tasks and requirements should be reused across use cases.
 
 ### General File Format Guidelines
 
@@ -156,8 +164,8 @@ Thank you for being here and for being a part of the CFDE project!
    use case | uc-0000 | uc-0001-researcher-browse-and-filter.md
    persona | p-000 | p-001-clinical-researcher.md
    objective | obj-0000 | obj-0001-create-data-release.md
-   user task | t-0000 | t-0001-access-cfde-interface.md
    requirement | r-00000 | r-00001-the-interface-will-support-gui-web-access-to-end-users.md
+   user task | t-0000 | t-0001-access-cfde-interface.md
 
 The **file format** for all files should be written in Markdown.
 
@@ -171,7 +179,7 @@ The **file format** for all files should be written in Markdown.
 [Clinical Researcher](./p-001-clinical-researcher.md)
 ```
 
-The **site index** is automatically created by yaml headers at the top of each file. These headers will automatically render links to the corresponding persona, objective, user task, and requirements files associated with a given use case. The Use Case committee will check yaml headers to ensure the indices do not clash with existing files.
+The **site index** is automatically created by yaml headers at the top of each file. These headers will automatically render links to a use case's corresponding persona, objective, user task, and requirements files associated. The Use Case committee will check yaml headers to ensure the indices do not clash with existing files.
 
 Yaml format begins and ends with "---". Every use case library page should have a `title:` key. For the [use case](#use-case-files) (uc-0000) and [user task](#user-task-files) (t-0000) files, additional keys and values are currently required. The additional keys (e.g., `requirements:`) are followed by a colon ":" and their corresponding values are listed after with a hyphen "-" and the file ID. Yaml keys may have one or more values. For example, the `requirements:` key below is linked to the `r-00003` and `r-00004` requirements file IDs:
 
@@ -184,33 +192,35 @@ requirements:
 ---
 ```
 
-### `Use Case` files <a name="use-case-files"></a>
+### Specific File Format Guidelines
+
+#### `Use Case` files <a name="use-case-files"></a>
 - Use the [use case file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-uc-template.md) to enter the required sections
 - Required sections:
     - yaml index header, including keys for `title:`, `persona:`, `objective:`, `user_tasks:`, and `requirements:`
     - a short summary of the use case
 
-### `Persona` files
+#### `Persona` files <a name="persona-files"></a>
 - Use the [persona file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-persona-template.md) to enter the required sections
 - Required sections:
     - yaml index header with `title:`
     - Short description of the persona's biological/computational experience, their role and responsibilities, and relation to any of the other personas in the Use Case Library
     - A bullet point section listing assumptions about the persona's credentials e.g., access to the CFDE
 
-### `Objective` files
+#### `Objective` files <a name="obj-files"></a>
 - Use the [objective file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-obj-template.md) to enter the required sections
 - Required sections:
     - yaml index header with `title:`
     - a brief ~1-2 sentence description of the objective
 
-### `User task` files <a name="user-task-files"></a>
-- The User Tasks title should be short and self-explanatory, but please add a short description as needed for clarity
-- Use the [user task file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-task-template.md) to enter the required sections
-- Required sections:
-    - yaml index header with `title:` and `requirements:`
-
-### `Requirement` files
+#### `Requirement` files <a name="req-files"></a>
 - The Requirements title should be short and self-explanatory, but please add a short description as needed for clarity
 - Use the [requirement file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-reqs-template.md) to enter the required sections
 - Required sections:
     - yaml index header with `title:`
+
+#### `User task` files <a name="user-task-files"></a>
+- The User Tasks title should be short and self-explanatory, but please add a short description as needed for clarity
+- Use the [user task file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-task-template.md) to enter the required sections
+- Required sections:
+    - yaml index header with `title:` and `requirements:`

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -27,18 +27,98 @@ If you are familiar with GitHub please either:
   - Or write up your use case and submit it as a pull request (PR). Please follow the [Use Case Style Guide](#usecasestyle) below.
 
 ### PR process
-If you are submitting a pull request, please create one pull request per use case so admin can check the complete change.
 
-  - [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the [use case library repo](https://github.com/nih-cfde/use-case-library-build) and create a new branch in your forked version.
+If you are submitting a pull request, please create one pull request per new use case so admin can check the complete change. Please check that the new additions render correctly on the website before submitting the PR by rendering the website locally on your computer. You will need to make a [Github account](https://github.com/) and install [`git`](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git/) and [`conda`](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) (e.g., by downloading Miniconda) on your computer. The instructions below have been tested on MacOS.
 
-  **New use case files should ONLY be added to the [`library` directory](https://github.com/nih-cfde/use-case-library-build/tree/latest/library). Please do not change any other files in the repository!**
+1\. [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the [use case library repo](https://github.com/nih-cfde/use-case-library-build) and create a new branch in your forked version. For those onboarded to the CFDE, you may have permissions to edit the use case library repo directly instead of forking.
 
-  - Use the [use case file templates](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates) to format and add your new use case files to the `library` directory on your branch.
-  - After you add changes to your branch, you should see a message near the top of the repo page indicating that your branch is x number of commits ahead of `nih-cfde:latest`. There should be a button for "Pull request" and/or "Compare" - they lead to the same page to create a PR. Submit a PR pushing changes from your branch to `nih-cfde:latest`.
-  - Request reviews from Use Case maintainers by typing `@ACharbonneau` and `@marisalim` in your PR text box
-  - Please allow up to one week for admin to review your request
+2\. Clone the repository to your local computer. Be sure to edit the command below with the correct Github user name:
+
+```
+git clone https://github.com/<your user name here>/use-case-library-test.git
+cd use-case-library-build
+```
+
+3\. Create a conda environment to specify the software used to build the use case library website. The name of the environment is specified by the `-n` flag, for example "usecaselibrary". The `-f` flag specifies the file that has all the software requirements. This website stores those requirements in a file called "environment.yml". Once you have made the conda environment, you can skip to step 4 for future edits (assuming you don't delete this conda environment!).
+
+```
+conda env create -n usecaselibrary -f environment.yml
+```
+
+4\. Activate the conda environment.
+
+```
+conda activate usecaselibrary
+```
+
+5\. Now, either make a branch or switch to the branch you're making edits on if it already exists (e.g., if you created a branch on Github, you can switch to work on the remote branch).
+
+```
+# make branch
+git branch <name of branch>
+
+# switch to local branch
+git checkout <name of branch>
+```
+```
+# OR switch to remote branch
+git checkout --track origin/<name of branch>
+```
+
+**New use case files should ONLY be added to the [`library` directory](https://github.com/nih-cfde/use-case-library-build/tree/latest/library). Please do not change any other files in the repository to prevent website rendering issues!**
+
+Use the [use case file templates](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates) to format and add your new use case files to the `library` directory on your branch.
+
+6\. After you've added the new use case files, preview how they look on the website! The website is built using snakemake rules. First, build the website's output directory. This should be done once. The `-j` flag specifies the number of cores to use; `-j 1` is sufficient for this website.
+
+```
+snakemake -j 1
+```
+
+7\. Generate the local render of the website. Scripts in this repository take the new files from the `library` directory, format them according to the website's stylesheets, and render them on the website.
+
+```
+snakemake serve -j 1
+```
+
+If this command executes successfully, copy the web address (`http://127.0.0.1:8000/`) to a web browser to check the changes you made. This is the local, offline version of the website! Note that if you continue to edit documents, you will need to use the `ctrl+c` keys on your keyboard to exit snakemake, save new changes, and re-run the `snakemake serve -j 1` command to view new changes.
+
+Your terminal should show the following if the local render succeeds:
+```
+INFO    -  Building documentation...
+INFO    -  Cleaning site directory
+INFO    -  Building documentation to directory: /var/folders/2k/dcjr_t3151z_s1yq8mlcv3f80000gn/T/mkdocs_alu91pc_
+INFO    -  Documentation built in 0.35 seconds
+INFO    -  Running at: http://127.0.0.1:8000/
+INFO    -  Hold ctrl+c to quit.
+```
+
+8\. If you are satisfied with the changes, you can add, commit, and push the changes to your forked repo.
+
+```
+# add all new changes
+git add .
+
+# commit changes
+git commit -am "short description of new changes"
+
+# push changes
+git push origin <name of branch>
+```
+
+If you are done working on the website, you can exit the conda environment to return to your base terminal environment.
+
+```
+conda deactivate
+```
+
+9\. After you push changes to your branch, you should see a message near the top of the Github repo page indicating that your branch is x number of commits ahead of `nih-cfde:latest`. There should be a button for "Pull request" and/or "Compare" - they lead to the same page to create a PR.
+- Submit a PR pushing changes from your branch to `nih-cfde:latest`.
+- Request reviews from Use Case maintainers by typing `@ACharbonneau` and `@marisalim` in your PR text box. Please check the to list in the PR text box (e.g., is the PR mergeable, etc.). You can continue to edit your PR after it has been submitted!
+- Please allow up to one week for admin to review your request.
 
 If you need help at any point in this process, please submit a [`HelpWanted issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=help+wanted&template=help_template.md&title=Add+problem+title)! Please include a reference (using `#`) to your PR number so we can check the submission.
+
 
 ### Use Case approval process
 

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -14,7 +14,7 @@ By contributing to this repository, you agree:
 1.  To obey the [Code of Conduct](./CODEOFCONDUCT.md)
 2.  To release all your contributions under the same terms as the license itself: the [CC-BY Attribution 4.0 International](./LICENSE.md)
 
-If you are OK with these two conditions, then we welcome both you and your contribution!
+If you are OK with these two conditions, then we welcome both you and your contribution to the CFDE project!
 
 ## Developing a new use case
 
@@ -48,15 +48,13 @@ Please allow up to one week for admin to review your suggestion.
 
 For use cases submitted as PRs, the Use Case committee will mark proposed use cases, and corresponding user task and requirement pages, with status and completion date. This information is added to the [yaml headers](#yaml-headers):
 
-- `in progress`=&#x23F3;
+- `in progress` = &#x23F3;
 
-- `approved`=&#x1F44C;
+- `approved` = &#x1F44C;
 
-- `done`=&#x2705;
+- `done` = &#x2705;
 
-Please do not delete these values as you edit files!
-
-Thank you for being here and for being a part of the CFDE project!
+Please do not delete these values as you edit files! We use these markers to keep track of complete use case files.
 
 ## Getting help
 
@@ -71,9 +69,9 @@ Issue templates | About
 
 ## Previewing content and submitting PR <a name="submit-pr"></a>
 
-If you are submitting a pull request, please create one pull request per new use case so admin can check the complete change. Please check that the new additions render correctly on the website before submitting the PR by rendering the website locally on your computer. You will need to make a [Github account](https://github.com/) and install [`git`](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git/) and [`conda`](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) (e.g., by downloading Miniconda) on your computer. The instructions below have been tested on MacOS.
+If you are submitting a pull request, please create one pull request per new use case so admin can check the complete change. Please check that the new additions render correctly on the website before submitting the PR by rendering the website locally on your computer. You will need to make a [Github account](https://github.com/) and install [`git`](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git/) and [`conda`](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) (e.g., by downloading Miniconda. [(MacOS Miniconda tutorial)](https://cfde-training-and-engagement.readthedocs-hosted.com/en/latest/Bioinformatics-Skills/install_conda_tutorial/)) on your computer. The instructions below have been tested on MacOS.
 
-1\. [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the [use case library repo](https://github.com/nih-cfde/use-case-library-build) and create a new branch in your forked version. For those onboarded to the CFDE, you may have permissions to edit the use case library repo directly instead of forking.
+1\. [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the [use case library repo](https://github.com/nih-cfde/use-case-library-build) and create a new branch in your forked version. For those onboarded to the CFDE, you may have permissions to edit the use case library repo directly instead of forking, in which case, start at step 2.
 
 2\. Clone the repository to your local computer. Be sure to edit the command below with the correct Github user name:
 
@@ -181,17 +179,7 @@ If you need help at any point in this process, please submit a [`HelpWanted issu
    user task | t-0000 | t-0001-access-cfde-interface.md
    requirement | r-00000 | r-00001-the-interface-will-support-gui-web-access-to-end-users.md
 
-The **file format** for all files should be written in Markdown.
-
-- For help with Markdown syntax, see this [basic syntax guide](https://www.markdownguide.org/basic-syntax/)
-- To add links to other pages:
-```
-# syntax
-[<text to click on>](<Github repo relative path to file>)
-
-# This is an example for a link to the Personas description page for "Clinical Researcher":
-[Clinical Researcher](./p-001-clinical-researcher.md)
-```
+The **file format** for all files should be written in Markdown. For help with Markdown syntax, see this [basic syntax guide](https://www.markdownguide.org/basic-syntax/).
 
 #### Yaml headers <a name="yaml-headers"></a>
 

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -129,6 +129,7 @@ conda deactivate
 ```
 
 9\. After you push changes to your branch, you should see a message near the top of the Github repo page indicating that your branch is x number of commits ahead of `nih-cfde:latest`. There should be a button for "Pull request" and/or "Compare" - they lead to the same page to create a PR.
+
 - Submit a PR pushing changes from your branch to `nih-cfde:latest`.
 - Request reviews from Use Case maintainers by typing `@ACharbonneau` and `@marisalim` in your PR text box. Please check the to list in the PR text box (e.g., is the PR mergeable, etc.). You can continue to edit your PR after it has been submitted!
 - Please allow up to one week for admin to review your request.

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -121,7 +121,7 @@ requirements:
 - Use the [objective file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-obj-template.md) to enter the required sections
 - Required sections:
     - yaml index header with `title:`
-    - **STILL NEEDED????** `<name of the task>`: brief ~1 sentence description of the task
+    - a brief ~1-2 sentence description of the objective
 
 ### `User task` files <a name="user-task-files"></a>
 - The User Tasks title should be short and self-explanatory, but please add a short description as needed for clarity

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Start by drafting the components of your new use case idea and then read through
 
 As necessary, you can also create new persona, objective, user task, or requirement files (see below for [file naming guidelines](#file-format-guide)). In particular, requirement files define the technical implementation for what needs to happen in user tasks. These may be difficult to define. You can include ideas for requirements with your use case submission and/or request help and we will reach out to the CFDE technical team for guidance.
 
-Please see the [Use Case Style Guide](#usecasestyle) for format instructions!
+Please see the [Use Case Library Style Guide](#usecasestyle) for format instructions!
 
 ## How to add content
 

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -81,7 +81,7 @@ snakemake -j 1
 snakemake serve -j 1
 ```
 
-If this command executes successfully, copy the web address (`http://127.0.0.1:8000/`) to a web browser to check the changes you made. This is the local, offline version of the website! Note that if you continue to edit documents, you will need to use the `ctrl+c` keys on your keyboard to exit snakemake, save new changes, and re-run the `snakemake serve -j 1` command to view new changes.
+If this command executes successfully, copy the web address (`http://127.0.0.1:8000/`) to a web browser to check the changes you made. This is the local, offline version of the website! Note that if you continue to edit documents, you will need to use the `ctrl+c` keys on your keyboard to close the server, save changes, and re-run the `snakemake serve -j 1` command to view new changes.
 
 Your terminal should show the following if the local render succeeds:
 ```

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -16,7 +16,7 @@ By contributing to this repository, you agree:
 
 If you are OK with these two conditions, then we welcome both you and your contribution!
 
-## How to develop a new use case
+## Developing a new use case
 
 Each **use case** must include:
 
@@ -26,23 +26,42 @@ Each **use case** must include:
 - specific [**user tasks**](./glossary.md#user-task)
 - technical infrastructure [**requirements**](./glossary.md#requirement) associated with user tasks
 
-Start by drafting the components of your new use case idea and then read through the [use case library's](./full_list.md) existing persona, objective, user task, and requirement definitions. If any of them apply to your new use case, please reuse them! For example, multiple use cases may involve the persona "clinical researcher" (p-001) or the user task "access CFDE interface" (t-0001), so these *existing* files can be referenced in the new use case files and do *not* need to be recreated.
+Start by drafting the components of your new use case idea and then read through the [use case library's](./full_list.md) existing persona, objective, user task, and requirement definitions. If any of them apply to your new use case, *please reuse them*! For example, multiple use cases may involve the persona "clinical researcher" (p-001) or the user task "access CFDE interface" (t-0001), so these *existing* files can be referenced in the new use case files and do *not* need to be recreated.
 
 As necessary, you can also create new persona, objective, user task, or requirement files (see below for [file naming guidelines](#file-format-guide)). In particular, requirement files define the technical implementation for what needs to happen in user tasks. These may be difficult to define. You can include ideas for requirements with your use case submission and/or request help and we will reach out to the CFDE technical team for guidance.
 
-Please see the [Use Case Library Style Guide](#usecasestyle) for format instructions!
+Please see the [Use Case Library Style Guide](#usecasestyle) for format instructions.
 
-## How to add content
+## Suggesting a new use case
 
-If you have a suggestion for a new use case concept and are not familiar with GitHub, you can [email your idea to us](mailto:support@cfde.atlassian.net).
+- If you have a suggestion for a new use case concept and are not familiar with GitHub, you can [email your idea to us](mailto:support@cfde.atlassian.net).
 
-If you are familiar with GitHub please either:
+- If you are familiar with GitHub please either:
 
-  - Open a [`NewUseCase issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=new+use+case&template=NewUseCase_template.md&title=Add+use+case+idea+title) describing your new use case idea
+    - Open a [`NewUseCase issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=new+use+case&template=NewUseCase_template.md&title=Add+use+case+idea+title) describing your new use case idea
 
-  - Or write up your use case and submit it as a pull request (PR).
+    - Or write up your use case and submit it as a pull request (PR) ([instructions below](#submit-pr)).
 
-### PR process
+### Use Case approval process
+
+Please allow up to one week for admin to review your suggestion.
+
+For use cases submitted as PRs, the Use Case committee will mark proposed use cases, and corresponding requirements pages, as `in progress`=&#x23F3;, `approved`=&#x1F44C;, and `done`=&#x2705;, as appropriate.
+
+Thank you for being here and for being a part of the CFDE project!
+
+## Getting help
+
+If you have any questions about contributing, please submit an issue and we will lend a hand as soon as possible:
+
+Issue templates | About
+--- | ---
+[`NewUseCase issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=new+use+case&template=NewUseCase_template.md&title=Add+use+case+idea+title) | To describe and suggest a new use case idea
+[`Enhancements issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=enhancement&template=Enhancement_template.md&title=Add+suggested+enhancement+title) | To suggest general improvements to the Use Case Library
+[`HelpWanted issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=help+wanted&template=help_template.md&title=Add+problem+title) | To request general help
+[`Bug report issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=bug&template=bug_template.md&title=Add+bug+title) | To report a bug
+
+## Previewing content and submitting PR <a name="submit-pr"></a>
 
 If you are submitting a pull request, please create one pull request per new use case so admin can check the complete change. Please check that the new additions render correctly on the website before submitting the PR by rendering the website locally on your computer. You will need to make a [Github account](https://github.com/) and install [`git`](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git/) and [`conda`](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) (e.g., by downloading Miniconda) on your computer. The instructions below have been tested on MacOS.
 
@@ -97,8 +116,6 @@ snakemake -j 1
 snakemake serve -j 1
 ```
 
-If this command executes successfully, copy the web address (`http://127.0.0.1:8000/`) to a web browser to check the changes you made. This is the local, offline version of the website! Note that if you continue to edit documents, you will need to use the `ctrl+c` keys on your keyboard to close the server, save changes, and re-run the `snakemake serve -j 1` command to view new changes.
-
 Your terminal should show the following if the local render succeeds:
 ```
 INFO    -  Building documentation...
@@ -108,6 +125,8 @@ INFO    -  Documentation built in 0.35 seconds
 INFO    -  Running at: http://127.0.0.1:8000/
 INFO    -  Hold ctrl+c to quit.
 ```
+
+If this command executes successfully, copy the web address (`http://127.0.0.1:8000/`) to a web browser to check the changes you made. This is the local, offline version of the website! Note that if you continue to edit documents, you will need to use the `ctrl+c` keys on your keyboard to close the server, save changes, and re-run the `snakemake serve -j 1` command to view new changes.
 
 8\. If you are satisfied with the changes, you can add, commit, and push the changes to your forked repo.
 
@@ -131,26 +150,10 @@ conda deactivate
 9\. After you push changes to your branch, you should see a message near the top of the Github repo page indicating that your branch is x number of commits ahead of `nih-cfde:latest`. There should be a button for "Pull request" and/or "Compare" - they lead to the same page to create a PR.
 
 - Submit a PR pushing changes from your branch to `nih-cfde:latest`.
-- Request reviews from Use Case maintainers by typing `@ACharbonneau` and `@marisalim` in your PR text box. Please check the to list in the PR text box (e.g., is the PR mergeable, etc.). You can continue to edit your PR after it has been submitted!
+- Request reviews from Use Case maintainers by typing `@ACharbonneau` and `@marisalim` in your PR text box. Please check the to do list in the PR text box (e.g., is the PR mergeable?, etc.). You can continue to edit your PR after it has been submitted!
 - Please allow up to one week for admin to review your request.
 
-If you need help at any point in this process, please submit a [`HelpWanted issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=help+wanted&template=help_template.md&title=Add+problem+title)! Please include a reference (using `#`) to your PR number so we can check the submission.
-
-
-### Use Case approval process
-
-The Use Case committee will mark proposed use cases, and corresponding requirements pages, as `in progress`=&#x23F3;, `approved`=&#x1F44C;, and `done`=&#x2705;, as appropriate.
-
-If you have any questions about contributing, please submit an issue and we will lend a hand as soon as possible:
-
-Issue templates | About
---- | ---
-[`NewUseCase issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=new+use+case&template=NewUseCase_template.md&title=Add+use+case+idea+title) | To describe and suggest a new use case idea
-[`Enhancements issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=enhancement&template=Enhancement_template.md&title=Add+suggested+enhancement+title) | To suggest general improvements to the Use Case Library
-[`HelpWanted issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=help+wanted&template=help_template.md&title=Add+problem+title) | To request general help
-[`Bug report issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=bug&template=bug_template.md&title=Add+bug+title) | To report a bug
-
-Thank you for being here and for being a part of the CFDE project!
+If you need help at any point in this process, please submit a [`HelpWanted issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=help+wanted&template=help_template.md&title=Add+problem+title)! Please include a reference (using `#`) to your PR number so we can check the correct submission.
 
 ## Use Case Library Style Guide <a name="usecasestyle"></a>
 

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -246,7 +246,7 @@ requirements:
 
 ## CFDE Program goals and objectives <a name="cfde-goals"></a>
 
-The following four goals may be added to [use case file yaml header](#use-case-files) if appropriate, for example, this is the beginning of the yaml header for the Researcher Browse and Filter use case:
+The following four goals may be added to the [use case file yaml header](#use-case-files) if appropriate. For example, this is the beginning of the yaml header for the "Researcher Browse and Filter" use case:
 
 ```
 ---

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -147,6 +147,10 @@ git commit -am "short description of new changes"
 
 # push changes
 git push origin <name of branch>
+
+# if you want to push a new local branch that is not on the remote repo yet
+# add the -u flag (also known as --set-upstream)
+# git push -u origin <name of branch>
 ```
 
 If you are done working on the website, you can exit the conda environment to return to your base terminal environment.

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -5,9 +5,9 @@ parent: Home
 nav_order: 2
 ---
 
-# Contributing to the nih-cfde Use Case Repository
+# Contributing to the NIH CFDE Use Case Library
 
-Hello, and thank you for your interest in contributing to the CFDE Use Case Repository!
+Hello, and thank you for your interest in contributing to the CFDE Use Case Library!
 
 By contributing to this repository, you agree:
 
@@ -15,6 +15,22 @@ By contributing to this repository, you agree:
 2.  To release all your contributions under the same terms as the license itself: the [CC-BY Attribution 4.0 International](./LICENSE.md)
 
 If you are OK with these two conditions, then we welcome both you and your contribution!
+
+## How to develop a new use case
+
+Each **use case** must include:
+
+- a [**persona**](./glossary.md#persona)
+- an [**objective**](./glossary.md#objective)
+- a [**summary**](./glossary.md#summary) of the objective
+- specific [**user tasks**](./glossary.md#user-task)
+- technical infrastructure [**requirements**](./glossary.md#requirement) associated with user tasks
+
+Start by drafting the components of your new use case idea and then read through the [use case library's](./full_list.md) existing persona, objective, user task, and requirement definitions. If any of them apply to your new use case, please reuse them! For example, multiple use cases may involve the persona "clinical researcher" (p-001) or the user task "access CFDE interface" (t-0001), so these *existing* files can be referenced in the new use case files and do *not* need to be recreated.
+
+As necessary, you can also create new persona, objective, user task, or requirement files (see below for [file naming guidelines](#file-format-guide)). In particular, requirement files define the technical implementation for what needs to happen in user tasks. These may be difficult to define. You can include ideas for requirements with your use case submission and/or request help and we will reach out to the CFDE technical team for guidance.
+
+Please see the [Use Case Style Guide](#usecasestyle) for format instructions!
 
 ## How to add content
 
@@ -24,7 +40,7 @@ If you are familiar with GitHub please either:
 
   - Open a [`NewUseCase issue`](https://github.com/nih-cfde/use-case-library-build/issues/new?labels=new+use+case&template=NewUseCase_template.md&title=Add+use+case+idea+title) describing your new use case idea
 
-  - Or write up your use case and submit it as a pull request (PR). Please follow the [Use Case Style Guide](#usecasestyle) below.
+  - Or write up your use case and submit it as a pull request (PR).
 
 ### PR process
 
@@ -137,25 +153,7 @@ Thank you for being here and for being a part of the CFDE project!
 
 ## Use Case Repository Style Guide <a name="usecasestyle"></a>
 
-### Use Case Structure
-
-- All use cases must have:
-    - a [**persona**](./glossary.md#persona)
-    - an [**objective**](./glossary.md#objective)
-    - a [**summary**](./glossary.md#summary) of the objective
-    - technical infrastructure [**requirements**](./glossary.md#requirement)
-    - specific [**user tasks**](./glossary.md#user-task)
-
-- Each use case submission consists of five types of file:
-    - 1 [use case file](#use-case-files)
-    - 1 [persona files](#persona-files)
-    - 1 [objective file](#obj-files)
-    - 1 or more [requirement files](#req-files)
-    - 1 or more [user task files](#user-task-files)
-
-Each persona, objective, requirement, and user task needs its own page and will be linked to the associated use case page(s). Common user tasks and requirements should be reused across use cases.
-
-### General File Format Guidelines
+### General File Format Guidelines <a name="file-format-guide"></a>
 
 **File names** should be lower case, use hyphens between words, and match the page titles (but try to keep them concise). All files should include a unique file ID. As indicated below, please add the appropriate number of leading 0's to the file IDs. The Use Case committee will finalize file IDs to ensure they do not clash with existing IDs.
 
@@ -164,8 +162,8 @@ Each persona, objective, requirement, and user task needs its own page and will 
    use case | uc-0000 | uc-0001-researcher-browse-and-filter.md
    persona | p-000 | p-001-clinical-researcher.md
    objective | obj-0000 | obj-0001-create-data-release.md
-   requirement | r-00000 | r-00001-the-interface-will-support-gui-web-access-to-end-users.md
    user task | t-0000 | t-0001-access-cfde-interface.md
+   requirement | r-00000 | r-00001-the-interface-will-support-gui-web-access-to-end-users.md
 
 The **file format** for all files should be written in Markdown.
 
@@ -196,6 +194,11 @@ requirements:
 
 #### `Use Case` files <a name="use-case-files"></a>
 - Use the [use case file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-uc-template.md) to enter the required sections
+- Each use case file submission must reference four types of file in the yaml header for the website to render properly:
+    - 1 or more [persona files](#persona-files)
+    - 1 or more [objective files](#obj-files)
+    - 1 or more [user task files](#user-task-files)
+    - 1 or more [requirement files](#req-files)
 - Required sections:
     - yaml index header, including keys for `title:`, `persona:`, `objective:`, `user_tasks:`, and `requirements:`
     - a short summary of the use case
@@ -213,14 +216,15 @@ requirements:
     - yaml index header with `title:`
     - a brief ~1-2 sentence description of the objective
 
-#### `Requirement` files <a name="req-files"></a>
-- The Requirements title should be short and self-explanatory, but please add a short description as needed for clarity
-- Use the [requirement file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-reqs-template.md) to enter the required sections
-- Required sections:
-    - yaml index header with `title:`
-
 #### `User task` files <a name="user-task-files"></a>
-- The User Tasks title should be short and self-explanatory, but please add a short description as needed for clarity
 - Use the [user task file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-task-template.md) to enter the required sections
+- The User Tasks title should be short and self-explanatory. You can add a short description in the main text (not yaml header) as needed for clarity.
+- Each user task must reference 1 or more requirements in the yaml header for the website to render properly
 - Required sections:
     - yaml index header with `title:` and `requirements:`
+
+#### `Requirement` files <a name="req-files"></a>
+- Use the [requirement file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-reqs-template.md) to enter the required sections
+- The Requirements title should be short and self-explanatory. You can add a short description in the main text (not yaml header) as needed for clarity.
+- Required sections:
+    - yaml index header with `title:`

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -191,20 +191,27 @@ The **file format** for all files should be written in Markdown.
 
 #### Yaml headers <a name="yaml-headers"></a>
 
-The **site index** is automatically created by yaml headers at the top of each file. These headers will automatically render links to a use case's corresponding persona, objective, user task, and requirements files associated. The Use Case committee will check yaml headers to ensure the indices do not clash with existing files.
+The **site index** is automatically created by yaml headers at the top of each file. These headers will automatically render links to a use case's corresponding persona, objective, user task, and requirements files. The Use Case committee will check yaml headers to ensure the indices do not clash with existing files.
 
-Yaml format begins and ends with "---". Every use case library page should have a `title:` key. For the [use case](#use-case-files) (uc-0000) and [user task](#user-task-files) (t-0000) files, additional keys and values are currently required. The additional keys (e.g., `requirements:`) are followed by a colon ":" and their corresponding values are listed after with a hyphen "-" and the file ID. Yaml keys may have one or more values. For example, the `requirements:` key below is linked to the `r-00003` and `r-00004` requirements file IDs:
+Yaml format begins and ends with "---". Every use case library page should have a `title:` key. For the [use case](#use-case-files) (uc-0000), [user task](#user-task-files) (t-0000), and [requirement](#req-files) (r-00000) files, additional keys and values are required (see file sections for [details](#specific-guide)).
+
+The `completed:` and `tutorial:` keys must be included in the yaml header, but their values should be left empty; the Use Case committee will fill them in. The `goal:` key may be filled in with applicable [CFDE program goals](#cfde-goals) or left for the Use Case committee to fill in.
+
+The other additional keys (`persona:`, `objective:`, `user_tasks:`, `requirements:`) are followed by a colon ":" and their corresponding values are listed after with a hyphen "-" and the file ID. These yaml keys may have one or more values.
+
+For example, the `requirements:` key below is linked to the `r-00003` and `r-00004` requirements file IDs and the `completed:` key is left empty:
 
 ```
 ---
 title: example user task
+completed:
 requirements:
 - r-00003
 - r-00004
 ---
 ```
 
-### Specific File Format Guidelines
+### Specific File Format Guidelines <a name="specific-guide"></a>
 
 #### `Use Case` files <a name="use-case-files"></a>
 - Use the [use case file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-uc-template.md) to enter the required sections
@@ -222,7 +229,7 @@ requirements:
 - **Required sections:**
     - yaml index header with `title:`
     - Short description of the persona's biological/computational experience, their role and responsibilities, and relation to any of the other personas in the Use Case Library
-    - A bullet point section listing assumptions about the persona's credentials e.g., access to the CFDE
+    - A bullet point section listing assumptions about the persona e.g., access to the CFDE
 
 #### `Objective` files <a name="obj-files"></a>
 - Use the [objective file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-obj-template.md) to enter the required sections

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -42,11 +42,19 @@ Please see the [Use Case Library Style Guide](#usecasestyle) for format instruct
 
     - Or write up your use case and submit it as a pull request (PR) ([instructions below](#submit-pr)).
 
-### Use Case approval process
+### Use Case approval process <a name="approval-process"></a>
 
 Please allow up to one week for admin to review your suggestion.
 
-For use cases submitted as PRs, the Use Case committee will mark proposed use cases, and corresponding requirements pages, as `in progress`=&#x23F3;, `approved`=&#x1F44C;, and `done`=&#x2705;, as appropriate.
+For use cases submitted as PRs, the Use Case committee will mark proposed use cases, and corresponding user task and requirement pages, with status and completion date. This information is added to the [yaml headers](#yaml-headers):
+
+- `in progress`=&#x23F3;
+
+- `approved`=&#x1F44C;
+
+- `done`=&#x2705;
+
+Please do not delete these values as you edit files!
 
 Thank you for being here and for being a part of the CFDE project!
 
@@ -181,6 +189,8 @@ The **file format** for all files should be written in Markdown.
 [Clinical Researcher](./p-001-clinical-researcher.md)
 ```
 
+#### Yaml headers <a name="yaml-headers"></a>
+
 The **site index** is automatically created by yaml headers at the top of each file. These headers will automatically render links to a use case's corresponding persona, objective, user task, and requirements files associated. The Use Case committee will check yaml headers to ensure the indices do not clash with existing files.
 
 Yaml format begins and ends with "---". Every use case library page should have a `title:` key. For the [use case](#use-case-files) (uc-0000) and [user task](#user-task-files) (t-0000) files, additional keys and values are currently required. The additional keys (e.g., `requirements:`) are followed by a colon ":" and their corresponding values are listed after with a hyphen "-" and the file ID. Yaml keys may have one or more values. For example, the `requirements:` key below is linked to the `r-00003` and `r-00004` requirements file IDs:
@@ -203,32 +213,34 @@ requirements:
     - 1 or more [objective files](#obj-files)
     - 1 or more [user task files](#user-task-files)
     - 1 or more [requirement files](#req-files)
-- Required sections:
-    - yaml index header, including keys for `title:`, `persona:`, `objective:`, `user_tasks:`, and `requirements:`
+- **Required sections:**
+    - yaml index header, including keys for `title:`, `completed:`, `tutorial:`, `goals:`, `persona:`, `objective:`, `user_tasks:`, and `requirements:`. The `completed:`, `tutorial:`, and `goals:` keys should be left empty; the Use Case committee will add information during the [approval process](#approval-process).
     - a short summary of the use case
 
 #### `Persona` files <a name="persona-files"></a>
 - Use the [persona file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-persona-template.md) to enter the required sections
-- Required sections:
+- **Required sections:**
     - yaml index header with `title:`
     - Short description of the persona's biological/computational experience, their role and responsibilities, and relation to any of the other personas in the Use Case Library
     - A bullet point section listing assumptions about the persona's credentials e.g., access to the CFDE
 
 #### `Objective` files <a name="obj-files"></a>
 - Use the [objective file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-obj-template.md) to enter the required sections
-- Required sections:
+- **Required sections:**
     - yaml index header with `title:`
     - a brief ~1-2 sentence description of the objective
 
 #### `User task` files <a name="user-task-files"></a>
 - Use the [user task file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-task-template.md) to enter the required sections
-- The User Tasks title should be short and self-explanatory. You can add a short description in the main text (not yaml header) as needed for clarity.
+- The User Tasks title should be short and self-explanatory
 - Each user task must reference 1 or more requirements in the yaml header for the website to render properly. **This list should include the subset of requirements corresponding to the specific user task that are listed in the [use case file's](#use-case-files) yaml requirements section.**
-- Required sections:
-    - yaml index header with `title:` and `requirements:`
+- **Required sections:**
+    - yaml index header with `title:`, `completed:`, and `requirements:`. The `completed:` key should be left empty; the Use Case committee will add information during the [approval process](#approval-process).
+    - a brief ~1-2 sentence description of the user task
 
 #### `Requirement` files <a name="req-files"></a>
 - Use the [requirement file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-reqs-template.md) to enter the required sections
-- The Requirements title should be short and self-explanatory. You can add a short description in the main text (not yaml header) as needed for clarity.
-- Required sections:
-    - yaml index header with `title:`
+- The Requirements title should be short and self-explanatory.
+- **Required sections:**
+    - yaml index header with `title:` and `completed:`. The `completed:` key should be left empty; the Use Case committee will add information during the [approval process](#approval-process).
+    - a brief ~1-2 sentence description of the requirement

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -223,7 +223,7 @@ requirements:
 #### `User task` files <a name="user-task-files"></a>
 - Use the [user task file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-task-template.md) to enter the required sections
 - The User Tasks title should be short and self-explanatory. You can add a short description in the main text (not yaml header) as needed for clarity.
-- Each user task must reference 1 or more requirements in the yaml header for the website to render properly. **This list should only include requirements listed in the [use case file's](#use-case-files) yaml requirements section.**
+- Each user task must reference 1 or more requirements in the yaml header for the website to render properly. **This list should include the subset of requirements corresponding to the specific user task that are listed in the [use case file's](#use-case-files) yaml requirements section.**
 - Required sections:
     - yaml index header with `title:` and `requirements:`
 

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -220,7 +220,7 @@ requirements:
 #### `User task` files <a name="user-task-files"></a>
 - Use the [user task file template](https://github.com/nih-cfde/use-case-library-build/tree/latest/library_file_templates/library-task-template.md) to enter the required sections
 - The User Tasks title should be short and self-explanatory. You can add a short description in the main text (not yaml header) as needed for clarity.
-- Each user task must reference 1 or more requirements in the yaml header for the website to render properly
+- Each user task must reference 1 or more requirements in the yaml header for the website to render properly. **This list should only include requirements listed in the [use case file's](#use-case-files) yaml requirements section.**
 - Required sections:
     - yaml index header with `title:` and `requirements:`
 

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -214,7 +214,7 @@ requirements:
     - 1 or more [user task files](#user-task-files)
     - 1 or more [requirement files](#req-files)
 - **Required sections:**
-    - yaml index header, including keys for `title:`, `completed:`, `tutorial:`, `goals:`, `persona:`, `objective:`, `user_tasks:`, and `requirements:`. The `completed:`, `tutorial:`, and `goals:` keys should be left empty; the Use Case committee will add information during the [approval process](#approval-process).
+    - yaml index header, including keys for `title:`, `completed:`, `tutorial:`, `goal:`, `persona:`, `objective:`, `user_tasks:`, and `requirements:`. The `completed:`, and `tutorial:` keys should be left empty; the Use Case committee will add information during the [approval process](#approval-process). Optional: You can fill in the `goal:` key according to the [list of CFDE program goals](#cfde-goals).
     - a short summary of the use case
 
 #### `Persona` files <a name="persona-files"></a>
@@ -244,3 +244,42 @@ requirements:
 - **Required sections:**
     - yaml index header with `title:` and `completed:`. The `completed:` key should be left empty; the Use Case committee will add information during the [approval process](#approval-process).
     - a brief ~1-2 sentence description of the requirement
+
+## CFDE Program goals and objectives <a name="cfde-goals"></a>
+
+The following four goals may be added to [use case file yaml header](#use-case-files) if appropriate, for example, this is the beginning of the yaml header for the Researcher Browse and Filter use case:
+
+```
+---
+title: Researcher Browse and Filter
+completed:
+tutorial:
+goal: Enhance the ability to ask scientific questions across data sets
+---
+```
+
+The four key goals of the CFDE are detailed below:
+
+### Goal 1: Enhance the ability to ask scientific questions across data sets
+- 1a. Novel scientific and clinical research is enabled through cross-data set discovery
+- 1b. A standard Authentication/Authorization (AuthN/AuthZ) strategy is implemented to permit appropriate access to and compute on controlled access data
+- 1c. (Eval only) CFDE activities are having a positive impact on CF DCCs’ ability to manage and use data
+
+### Goal 2: Enable the uptake, reuse, and addition of NIH data and tools from future, current, and ended programs
+- 2a. Data and metadata structure, descriptions, and organization are optimized so data can be found and combined across data sets
+- 2b. Common standards, methods, tools, and processes are provided enabling data managers to load, update, maintain and version, and monitor data sets on the cloud
+- 2c. Common tools and processes are provided to assess and improve FAIR-ness of data and other digital objects to optimize the query, retrieval, and use
+- 2d. A central, externally facing, scalable portal is provided, serving as the directory to all CF data sets and tools, FAIR-ness metrics, use cases, and the like
+- 2e. CF DCCs and their users are engaged in the design of self-governed standards applicable to existing and future CF data programs
+
+### Goal 3: Support the storage, sharing, and sustainability of CF data sets
+- 3a. CF data sets are stored and managed in cloud environments to increase availability and accessibility of key data sets
+- 3b. CF Programs use the STRIDES agreements for storage and compute, leveraging
+pre-paid funding from the CF
+- 3c. NIH retains ownership and oversight of data sets after programs have ended
+- 3d. Practices and policies that can accommodate new CF programs are adopted
+
+### Goal 4: Provide training that maximizes a scientist’s ability to upload data and use CF data and other resources
+- 4a. Training material is provided for researchers to access, analyze and understand the CF data sets and tools provided by CF Programs
+- 4b. Use case scenarios are posted to the Data Ecosystem community
+- 4c. A Data Ecosystem user guide and site documentation are created and accessible

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -151,7 +151,7 @@ Issue templates | About
 
 Thank you for being here and for being a part of the CFDE project!
 
-## Use Case Repository Style Guide <a name="usecasestyle"></a>
+## Use Case Library Style Guide <a name="usecasestyle"></a>
 
 ### General File Format Guidelines <a name="file-format-guide"></a>
 


### PR DESCRIPTION
Updated how to contribute to the use case library - PR steps (minus info about previewing for now), file formats, templates for contributors to use (different from the website's template docs). Also updated the PR template to get rid of the RTD preview steps. 