### PR TITLE
Edit error msg to tell ppl to check reqs

### DIFF
--- a/library/uc-0008-dcc-validates-data.md
+++ b/library/uc-0008-dcc-validates-data.md
@@ -32,8 +32,8 @@ Kristin has just used the CFDE submission tool to make a new Review Catalog. The
 would like to preview that catalog in the CFDE portal, and approve it to be included
 in the Release Catalog.
 
-Kristin logs in to the portal using an existing identity, and clicks through to the Review 
-page, a restricted page showing summary statistics about the current Review Catalog. 
+Kristin logs in to the portal using an existing identity, and clicks through to the Review
+page, a restricted page showing summary statistics about the current Review Catalog.
 This display helps her answer questions like:
 
 -   How many data files exist for her DCC overall?
@@ -47,4 +47,4 @@ This display helps her answer questions like:
 By comparing the summary statistics supplied by the interface, Kristin can determine
 whether the Review Catalog they submitted is what they expected given their data submission.
 Kristin can also do spot checks of the data, or see the outcome of specific searches by browsing
-the Review Catalog. 
+the Review Catalog.

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -35,7 +35,7 @@ def check_library_refs(obj_dict):
             if task_reqs != uc_reqs:
                 remainder = task_reqs ^ uc_reqs
                 idents = ", ".join(remainder)
-                warn = f"ERROR: use case has disjoint requirements with its tasks' requirements for {obj.ident}! Requirements are: {idents}"
+                warn = f"ERROR: use case has disjoint requirements with its tasks' requirements for {obj.ident}! Check these requirements: {idents}"
                 warnings.append(warn)
                 fail = True
 
@@ -51,7 +51,7 @@ def check_library_refs(obj_dict):
 
 def resolve_library_refs(obj_dict):
     """
-    For each library item, 
+    For each library item,
     resolve the references
     to other library items
     in the object dictionary.
@@ -122,7 +122,7 @@ def md_files_to_obj_dict(markdown_files):
     Given a set of Markdown files, load each
     markdown file header and content. Then
     create the appropriate library object,
-    and add it to obj_dict. When finished, 
+    and add it to obj_dict. When finished,
     return obj_dict.
     """
     obj_dict = {}
@@ -158,4 +158,3 @@ def md_files_to_obj_dict(markdown_files):
         sys.exit(-1)
 
     return obj_dict
-


### PR DESCRIPTION
This PR edits the `ERROR: use case has disjoint requirements with its tasks' requirements` error message to tell ppl they should check specific requirements. It would say e.g.,

`ERROR: use case has disjoint requirements with its tasks' requirements for uc-0008! Check these requirements: r-00039`